### PR TITLE
Fixed compilation issues

### DIFF
--- a/contracts/governance_standard/GovernorContract.sol
+++ b/contracts/governance_standard/GovernorContract.sol
@@ -6,6 +6,7 @@ import "@openzeppelin/contracts/governance/extensions/GovernorCountingSimple.sol
 import "@openzeppelin/contracts/governance/extensions/GovernorVotes.sol";
 import "@openzeppelin/contracts/governance/extensions/GovernorVotesQuorumFraction.sol";
 import "@openzeppelin/contracts/governance/extensions/GovernorTimelockControl.sol";
+import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Votes.sol";
 
 contract GovernorContract is
   Governor,
@@ -55,7 +56,7 @@ contract GovernorContract is
   function getVotes(address account, uint256 blockNumber)
     public
     view
-    override(IGovernor, GovernorVotes)
+    override(IGovernor, Governor)
     returns (uint256)
   {
     return super.getVotes(account, blockNumber);

--- a/contracts/optional/GovernanceTokenWrapper.sol
+++ b/contracts/optional/GovernanceTokenWrapper.sol
@@ -30,4 +30,8 @@ contract MyToken is ERC20, ERC20Permit, ERC20Votes, ERC20Wrapper {
   function _burn(address account, uint256 amount) internal override(ERC20, ERC20Votes) {
     super._burn(account, amount);
   }
+
+  function decimals() public view virtual override(ERC20, ERC20Wrapper) returns (uint8) { 
+    return 18;
+  }
 }


### PR DESCRIPTION
I got some issues while compiling the contracts. 

In `contracts/governance_standard/GovernorContract.sol` I got an error because of a missing import. And also because of the `getVotes` override, the one within the `GovernorVotes.sol` differs from the function in `Governor.sol `.

In `contracts/optional/GovernanceTokenWrapper.sol` I had to overwrite the decimals function. 
After that everything worked out fine and I was able to deploy it to Rinkeby. 

btw, @PatrickAlphaC thanks (again) for the amazing tutorial, I am one of the holders of all of your 5 Nfts :) 