### PR TITLE
Set allowUnlimitedContractSize to true

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -20,6 +20,7 @@ const config: HardhatUserConfig = {
   networks: {
     hardhat: {
       chainId: 31337,
+      allowUnlimitedContractSize: true
     },
     localhost: {
       chainId: 31337,


### PR DESCRIPTION
When running `yarn hardhat deploy` for the token, timelock and governance contracts, I faced the error:

**Error: cannot estimate gas; transaction may fail or may require manual gas limit [ See: https://links.ethers.org/v5-errors-UNPREDICTABLE_GAS_LIMIT ] (reason="Transaction reverted: trying to deploy a contract whose code is too large", method="estimateGas"... (followed by lots of bytes representing the transaction data for deploying the governance contract code)**

I Googled online and it seems making this change solved the issue.
